### PR TITLE
Support/create compact mode view

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11312,15 +11312,15 @@ class Slack {
                 : tmpText;
             let baseBlock = {
                 type: 'section',
-                text: slackBlockUI.baseFields
+                fields: slackBlockUI.baseFields
             };
             if (isCompactMode) {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-                baseBlock.text = compactModeFields;
+                baseBlock.fields = compactModeFields;
             }
             if (commitFlag && token) {
                 const commitFields = yield slackBlockUI.getCommitFields(token);
-                Array.prototype.push.apply(baseBlock.text, commitFields);
+                Array.prototype.push.apply(baseBlock.fields, commitFields);
             }
             const attachments = {
                 color: notificationType.color,

--- a/dist/index.js
+++ b/dist/index.js
@@ -11310,20 +11310,25 @@ class Slack {
             const text = mention && this.isMention(mentionCondition, status)
                 ? `<!${mention}> ${tmpText}`
                 : tmpText;
-            let baseBlock;
-            if (isCompactMode) {
-                const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-                baseBlock = {
-                    type: 'section',
-                    text: compactModeFields
-                };
-            }
-            else {
-                baseBlock = {
-                    type: 'section',
-                    fields: slackBlockUI.baseFields
-                };
-            }
+            const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
+            let baseBlock = {
+                type: 'section',
+                text: compactModeFields
+            };
+            // if (isCompactMode) {
+            //   const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
+            //     result
+            //   );
+            //   baseBlock = {
+            //     type: 'section',
+            //     text: compactModeFields
+            //   };
+            // } else {
+            //   baseBlock = {
+            //     type: 'section',
+            //     fields: slackBlockUI.baseFields
+            //   };
+            // }
             if (commitFlag && token) {
                 const commitFields = yield slackBlockUI.getCommitFields(token);
                 Array.prototype.push.apply(baseBlock['fields'], commitFields);

--- a/dist/index.js
+++ b/dist/index.js
@@ -11311,18 +11311,18 @@ class Slack {
                 ? `<!${mention}> ${tmpText}`
                 : tmpText;
             let baseBlock = {
-                type: 'section',
+                type: 'section'
             };
             if (isCompactMode) {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-                baseBlock["text"] = compactModeFields;
+                baseBlock['text'] = compactModeFields;
             }
             else {
-                baseBlock["fields"] = slackBlockUI.baseFields;
+                baseBlock['fields'] = slackBlockUI.baseFields;
             }
             if (commitFlag && token) {
                 const commitFields = yield slackBlockUI.getCommitFields(token);
-                Array.prototype.push.apply(baseBlock["fields"], commitFields);
+                Array.prototype.push.apply(baseBlock['fields'], commitFields);
             }
             const attachments = {
                 color: notificationType.color,

--- a/dist/index.js
+++ b/dist/index.js
@@ -11309,7 +11309,7 @@ class Slack {
                 ? `<!${mention}> ${tmpText}`
                 : tmpText;
             let baseBlock = {
-                type: 'section',
+                type: 'section'
             };
             if (isCompactMode) {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);

--- a/dist/index.js
+++ b/dist/index.js
@@ -11310,15 +11310,19 @@ class Slack {
             const text = mention && this.isMention(mentionCondition, status)
                 ? `<!${mention}> ${tmpText}`
                 : tmpText;
-            let baseBlock = {
-                type: 'section'
-            };
+            let baseBlock;
             if (isCompactMode) {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-                baseBlock['text'] = compactModeFields;
+                baseBlock = {
+                    type: 'section',
+                    text: compactModeFields,
+                };
             }
             else {
-                baseBlock['fields'] = slackBlockUI.baseFields;
+                baseBlock = {
+                    type: 'section',
+                    fields: slackBlockUI.baseFields
+                };
             }
             if (commitFlag && token) {
                 const commitFields = yield slackBlockUI.getCommitFields(token);

--- a/dist/index.js
+++ b/dist/index.js
@@ -11269,14 +11269,14 @@ class Block {
      */
     getCompactModeFields(status) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { sha, eventName, workflow, ref, actor } = this.context;
+            const { workflow, ref, actor } = this.context;
             const { owner, repo } = this.context.repo;
             const repoUrl = `https://github.com/${owner}/${repo}`;
             let actionUrl = repoUrl;
             const fields = [
                 {
                     type: 'mrkdwn',
-                    text: `It was ${status} on ${ref} by, check <${actionUrl}|${workflow}> ${actor} `
+                    text: `It was ${status} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
                 }
             ];
             return fields;

--- a/dist/index.js
+++ b/dist/index.js
@@ -11273,12 +11273,10 @@ class Block {
             const { owner, repo } = this.context.repo;
             const repoUrl = `https://github.com/${owner}/${repo}`;
             let actionUrl = repoUrl;
-            const fields = [
-                {
-                    type: 'mrkdwn',
-                    text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
-                }
-            ];
+            const fields = {
+                type: 'mrkdwn',
+                text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
+            };
             return fields;
         });
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -11267,7 +11267,7 @@ class Block {
      * Get MrkdwnElement for compact mode
      * @returns {Promise<MrkdwnElement[]>}
      */
-    getCompactModeFields(status) {
+    getCompactModeFields(notificationType) {
         return __awaiter(this, void 0, void 0, function* () {
             const { workflow, ref, actor } = this.context;
             const { owner, repo } = this.context.repo;
@@ -11276,7 +11276,7 @@ class Block {
             const fields = [
                 {
                     type: 'mrkdwn',
-                    text: `It was ${status} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+                    text: `It has ${notificationType.result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
                 }
             ];
             return fields;
@@ -11314,7 +11314,7 @@ class Slack {
                 fields: slackBlockUI.baseFields
             };
             if (isCompactMode) {
-                const compactModeFields = yield slackBlockUI.getCompactModeFields(status);
+                const compactModeFields = yield slackBlockUI.getCompactModeFields(notificationType);
                 baseBlock.fields = compactModeFields;
             }
             if (commitFlag && token) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11308,19 +11308,15 @@ class Slack {
             const text = mention && this.isMention(mentionCondition, status)
                 ? `<!${mention}> ${tmpText}`
                 : tmpText;
-            let baseBlock;
+            let baseBlock = {
+                type: 'section',
+            };
             if (isCompactMode) {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-                baseBlock = {
-                    type: 'section',
-                    text: compactModeFields
-                };
+                baseBlock['text'] = compactModeFields;
             }
             else {
-                baseBlock = {
-                    type: 'section',
-                    fields: slackBlockUI.baseFields
-                };
+                baseBlock['fields'] = slackBlockUI.baseFields;
                 if (commitFlag && token) {
                     const commitFields = yield slackBlockUI.getCommitFields(token);
                     Array.prototype.push.apply(baseBlock['fields'], commitFields);

--- a/dist/index.js
+++ b/dist/index.js
@@ -11312,15 +11312,17 @@ class Slack {
                 : tmpText;
             let baseBlock = {
                 type: 'section',
-                fields: slackBlockUI.baseFields
             };
             if (isCompactMode) {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-                baseBlock.fields = compactModeFields;
+                baseBlock["text"] = compactModeFields;
+            }
+            else {
+                baseBlock["fields"] = slackBlockUI.baseFields;
             }
             if (commitFlag && token) {
                 const commitFields = yield slackBlockUI.getCommitFields(token);
-                Array.prototype.push.apply(baseBlock.fields, commitFields);
+                Array.prototype.push.apply(baseBlock["fields"], commitFields);
             }
             const attachments = {
                 color: notificationType.color,

--- a/dist/index.js
+++ b/dist/index.js
@@ -11269,13 +11269,13 @@ class Block {
      */
     getCompactModeTextField(result) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { workflow, ref, actor } = this.context;
+            const { sha, workflow, ref, actor } = this.context;
             const { owner, repo } = this.context.repo;
             const repoUrl = `https://github.com/${owner}/${repo}`;
-            let actionUrl = repoUrl;
+            let actionUrl = `${repoUrl}/commit/${sha}/checks`;
             const textField = {
                 type: 'mrkdwn',
-                text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+                text: `<${repoUrl}|${owner}/${repo}> It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
             };
             return textField;
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -11267,17 +11267,17 @@ class Block {
      * Get MrkdwnElement for compact mode
      * @returns {Promise<MrkdwnElement[]>}
      */
-    getCompactModeFields(result) {
+    getCompactModeTextField(result) {
         return __awaiter(this, void 0, void 0, function* () {
             const { workflow, ref, actor } = this.context;
             const { owner, repo } = this.context.repo;
             const repoUrl = `https://github.com/${owner}/${repo}`;
             let actionUrl = repoUrl;
-            const fields = {
+            const textField = {
                 type: 'mrkdwn',
                 text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
             };
-            return fields;
+            return textField;
         });
     }
 }
@@ -11312,7 +11312,7 @@ class Slack {
                 type: 'section'
             };
             if (isCompactMode) {
-                const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
+                const compactModeFields = yield slackBlockUI.getCompactModeTextField(result);
                 baseBlock['text'] = compactModeFields;
             }
             else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11275,7 +11275,7 @@ class Block {
             let actionUrl = repoUrl;
             const fields = {
                 type: 'mrkdwn',
-                text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
+                text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
             };
             return fields;
         });
@@ -11308,28 +11308,23 @@ class Slack {
             const text = mention && this.isMention(mentionCondition, status)
                 ? `<!${mention}> ${tmpText}`
                 : tmpText;
-            const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-            let baseBlock = {
-                type: 'section',
-                text: compactModeFields
-            };
-            // if (isCompactMode) {
-            //   const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
-            //     result
-            //   );
-            //   baseBlock = {
-            //     type: 'section',
-            //     text: compactModeFields
-            //   };
-            // } else {
-            //   baseBlock = {
-            //     type: 'section',
-            //     fields: slackBlockUI.baseFields
-            //   };
-            // }
-            if (commitFlag && token) {
-                const commitFields = yield slackBlockUI.getCommitFields(token);
-                Array.prototype.push.apply(baseBlock['fields'], commitFields);
+            let baseBlock;
+            if (isCompactMode) {
+                const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
+                baseBlock = {
+                    type: 'section',
+                    text: compactModeFields
+                };
+            }
+            else {
+                baseBlock = {
+                    type: 'section',
+                    fields: slackBlockUI.baseFields
+                };
+                if (commitFlag && token) {
+                    const commitFields = yield slackBlockUI.getCommitFields(token);
+                    Array.prototype.push.apply(baseBlock['fields'], commitFields);
+                }
             }
             const attachments = {
                 color: notificationType.color,

--- a/dist/index.js
+++ b/dist/index.js
@@ -11269,11 +11269,11 @@ class Block {
      */
     getCompactModeFields() {
         return __awaiter(this, void 0, void 0, function* () {
+            const { sha, eventName, workflow, ref } = this.context;
             const fields = [
                 {
-                    // TODO GW-1878 create compact message
                     type: 'mrkdwn',
-                    text: 'this is compact mode'
+                    text: `on ${ref}`
                 }
             ];
             return fields;

--- a/dist/index.js
+++ b/dist/index.js
@@ -11265,7 +11265,7 @@ class Block {
     }
     /**
      * Get MrkdwnElement for compact mode
-     * @returns {Promise<MrkdwnElement[]>}
+     * @returns {Promise<MrkdwnElement>}
      */
     getCompactModeTextField(result) {
         return __awaiter(this, void 0, void 0, function* () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11276,7 +11276,7 @@ class Block {
             const fields = [
                 {
                     type: 'mrkdwn',
-                    text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+                    text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
                 }
             ];
             return fields;
@@ -11312,15 +11312,15 @@ class Slack {
                 : tmpText;
             let baseBlock = {
                 type: 'section',
-                fields: slackBlockUI.baseFields
+                text: slackBlockUI.baseFields
             };
             if (isCompactMode) {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
-                baseBlock.fields = compactModeFields;
+                baseBlock.text = compactModeFields;
             }
             if (commitFlag && token) {
                 const commitFields = yield slackBlockUI.getCommitFields(token);
-                Array.prototype.push.apply(baseBlock.fields, commitFields);
+                Array.prototype.push.apply(baseBlock.text, commitFields);
             }
             const attachments = {
                 color: notificationType.color,

--- a/dist/index.js
+++ b/dist/index.js
@@ -11315,7 +11315,7 @@ class Slack {
                 const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
                 baseBlock = {
                     type: 'section',
-                    text: compactModeFields,
+                    text: compactModeFields
                 };
             }
             else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11270,10 +11270,13 @@ class Block {
     getCompactModeFields(status) {
         return __awaiter(this, void 0, void 0, function* () {
             const { sha, eventName, workflow, ref } = this.context;
+            const { owner, repo } = this.context.repo;
+            const repoUrl = `https://github.com/${owner}/${repo}`;
+            let actionUrl = repoUrl;
             const fields = [
                 {
                     type: 'mrkdwn',
-                    text: `It has ${status} on ${ref}`
+                    text: `It has ${status} on ${ref}, check <${actionUrl}|${workflow}>`
                 }
             ];
             return fields;

--- a/dist/index.js
+++ b/dist/index.js
@@ -11267,7 +11267,7 @@ class Block {
      * Get MrkdwnElement for compact mode
      * @returns {Promise<MrkdwnElement[]>}
      */
-    getCompactModeFields(notificationType) {
+    getCompactModeFields(result) {
         return __awaiter(this, void 0, void 0, function* () {
             const { workflow, ref, actor } = this.context;
             const { owner, repo } = this.context.repo;
@@ -11276,7 +11276,7 @@ class Block {
             const fields = [
                 {
                     type: 'mrkdwn',
-                    text: `It has ${notificationType.result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+                    text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
                 }
             ];
             return fields;
@@ -11305,7 +11305,8 @@ class Slack {
         return __awaiter(this, void 0, void 0, function* () {
             const slackBlockUI = new Block();
             const notificationType = slackBlockUI[status];
-            const tmpText = `${jobName} ${notificationType.result}`;
+            const { result } = notificationType;
+            const tmpText = `${jobName} ${result}`;
             const text = mention && this.isMention(mentionCondition, status)
                 ? `<!${mention}> ${tmpText}`
                 : tmpText;
@@ -11314,7 +11315,7 @@ class Slack {
                 fields: slackBlockUI.baseFields
             };
             if (isCompactMode) {
-                const compactModeFields = yield slackBlockUI.getCompactModeFields(notificationType);
+                const compactModeFields = yield slackBlockUI.getCompactModeFields(result);
                 baseBlock.fields = compactModeFields;
             }
             if (commitFlag && token) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11267,13 +11267,13 @@ class Block {
      * Get MrkdwnElement for compact mode
      * @returns {Promise<MrkdwnElement[]>}
      */
-    getCompactModeFields() {
+    getCompactModeFields(status) {
         return __awaiter(this, void 0, void 0, function* () {
             const { sha, eventName, workflow, ref } = this.context;
             const fields = [
                 {
                     type: 'mrkdwn',
-                    text: `on ${ref}`
+                    text: `It has ${status} on ${ref}`
                 }
             ];
             return fields;
@@ -11311,7 +11311,7 @@ class Slack {
                 fields: slackBlockUI.baseFields
             };
             if (isCompactMode) {
-                const compactModeFields = yield slackBlockUI.getCompactModeFields();
+                const compactModeFields = yield slackBlockUI.getCompactModeFields(status);
                 baseBlock.fields = compactModeFields;
             }
             if (commitFlag && token) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11275,7 +11275,7 @@ class Block {
             let actionUrl = `${repoUrl}/commit/${sha}/checks`;
             const textField = {
                 type: 'mrkdwn',
-                text: `<${repoUrl}|${owner}/${repo}> It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+                text: `[<${repoUrl}|${owner}/${repo}>] It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
             };
             return textField;
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -11269,14 +11269,14 @@ class Block {
      */
     getCompactModeFields(status) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { sha, eventName, workflow, ref } = this.context;
+            const { sha, eventName, workflow, ref, actor } = this.context;
             const { owner, repo } = this.context.repo;
             const repoUrl = `https://github.com/${owner}/${repo}`;
             let actionUrl = repoUrl;
             const fields = [
                 {
                     type: 'mrkdwn',
-                    text: `It has ${status} on ${ref}, check <${actionUrl}|${workflow}>`
+                    text: `It was ${status} on ${ref} by, check <${actionUrl}|${workflow}> ${actor} `
                 }
             ];
             return fields;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "weseek-slack-notification",
+  "name": "weseek-ghaction-slack-notification",
   "version": "0.0.0",
   "description": "This is Slack Notification for GitHub Actions",
   "main": "lib/main.js",

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -121,18 +121,18 @@ class Block {
    * Get MrkdwnElement for compact mode
    * @returns {Promise<MrkdwnElement[]>}
    */
-  public async getCompactModeFields(result: String): Promise<MrkdwnElement> {
+  public async getCompactModeTextField(result: String): Promise<MrkdwnElement> {
     const {workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
     let actionUrl: string = repoUrl;
 
-    const fields: MrkdwnElement = {
+    const textField: MrkdwnElement = {
       type: 'mrkdwn',
       text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
     };
 
-    return fields;
+    return textField;
   }
 }
 
@@ -178,7 +178,7 @@ export class Slack {
     };
 
     if (isCompactMode) {
-      const compactModeFields: MrkdwnElement = await slackBlockUI.getCompactModeFields(
+      const compactModeFields: MrkdwnElement = await slackBlockUI.getCompactModeTextField(
         result
       );
       baseBlock['text'] = compactModeFields;

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -130,7 +130,7 @@ class Block {
     const fields: MrkdwnElement[] = [
       {
         type: 'mrkdwn',
-        text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+        text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
       }
     ];
 
@@ -176,21 +176,21 @@ export class Slack {
         : tmpText;
     let baseBlock = {
       type: 'section',
-      fields: slackBlockUI.baseFields
+      text: slackBlockUI.baseFields
     };
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
         result
       );
-      baseBlock.fields = compactModeFields;
+      baseBlock.text = compactModeFields;
     }
 
     if (commitFlag && token) {
       const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(
         token
       );
-      Array.prototype.push.apply(baseBlock.fields, commitFields);
+      Array.prototype.push.apply(baseBlock.text, commitFields);
     }
 
     const attachments: MessageAttachment = {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -122,11 +122,12 @@ class Block {
    * @returns {Promise<MrkdwnElement[]>}
    */
   public async getCompactModeFields(): Promise<MrkdwnElement[]> {
+    const {sha, eventName, workflow, ref} = this.context;
+
     const fields: MrkdwnElement[] = [
       {
-        // TODO GW-1878 create compact message
         type: 'mrkdwn',
-        text: 'this is compact mode'
+        text: `on ${ref}`
       }
     ];
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -176,21 +176,23 @@ export class Slack {
         : tmpText;
     let baseBlock = {
       type: 'section',
-      fields: slackBlockUI.baseFields
     };
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
         result
       );
-      baseBlock.fields = compactModeFields;
+      baseBlock["text"] = compactModeFields;
+    } 
+    else {
+      baseBlock["fields"] = slackBlockUI.baseFields
     }
 
     if (commitFlag && token) {
       const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(
         token
       );
-      Array.prototype.push.apply(baseBlock.fields, commitFields);
+      Array.prototype.push.apply(baseBlock["fields"], commitFields);
     }
 
     const attachments: MessageAttachment = {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -119,7 +119,7 @@ class Block {
 
   /**
    * Get MrkdwnElement for compact mode
-   * @returns {Promise<MrkdwnElement[]>}
+   * @returns {Promise<MrkdwnElement>}
    */
   public async getCompactModeTextField(result: String): Promise<MrkdwnElement> {
     const {workflow, ref, actor} = this.context;

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -122,15 +122,15 @@ class Block {
    * @returns {Promise<MrkdwnElement[]>}
    */
   public async getCompactModeFields(status: string): Promise<MrkdwnElement[]> {
-    const {sha, eventName, workflow, ref} = this.context;
+    const {sha, eventName, workflow, ref,actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
     let actionUrl: string = repoUrl;
-    
+
     const fields: MrkdwnElement[] = [
       {
         type: 'mrkdwn',
-        text: `It has ${status} on ${ref}, check <${actionUrl}|${workflow}>`
+        text: `It was ${status} on ${ref} by, check <${actionUrl}|${workflow}> ${actor} `
       }
     ];
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -122,14 +122,14 @@ class Block {
    * @returns {Promise<MrkdwnElement>}
    */
   public async getCompactModeTextField(result: String): Promise<MrkdwnElement> {
-    const {workflow, ref, actor} = this.context;
+    const {sha, workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
-    let actionUrl: string = repoUrl;
+    let actionUrl: string = `${repoUrl}/commit/${sha}/checks`;
 
     const textField: MrkdwnElement = {
       type: 'mrkdwn',
-      text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+      text: `<${repoUrl}|${owner}/${repo}> It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
     };
 
     return textField;

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -121,7 +121,7 @@ class Block {
    * Get MrkdwnElement for compact mode
    * @returns {Promise<MrkdwnElement[]>}
    */
-  public async getCompactModeFields(status: string): Promise<MrkdwnElement[]> {
+  public async getCompactModeFields(notificationType:Accessory): Promise<MrkdwnElement[]> {
     const {workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
@@ -130,7 +130,7 @@ class Block {
     const fields: MrkdwnElement[] = [
       {
         type: 'mrkdwn',
-        text: `It was ${status} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+        text: `It has ${notificationType.result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
       }
     ];
 
@@ -180,7 +180,7 @@ export class Slack {
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
-        status
+        notificationType,
       );
       baseBlock.fields = compactModeFields;
     }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -129,7 +129,7 @@ class Block {
 
     const textField: MrkdwnElement = {
       type: 'mrkdwn',
-      text: `<${repoUrl}|${owner}/${repo}> It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+      text: `[<${repoUrl}|${owner}/${repo}>] It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
     };
 
     return textField;

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -127,10 +127,9 @@ class Block {
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
     let actionUrl: string = repoUrl;
 
-    const fields: MrkdwnElement = 
-    {
+    const fields: MrkdwnElement = {
       type: 'mrkdwn',
-      text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
+      text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
     };
 
     return fields;
@@ -173,33 +172,29 @@ export class Slack {
       mention && this.isMention(mentionCondition, status)
         ? `<!${mention}> ${tmpText}`
         : tmpText;
-    const compactModeFields: MrkdwnElement = await slackBlockUI.getCompactModeFields(
-      result
-    );
-    let baseBlock = {
-      type: 'section',
-      text: compactModeFields
-    };
-    // if (isCompactMode) {
-    //   const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
-    //     result
-    //   );
-    //   baseBlock = {
-    //     type: 'section',
-    //     text: compactModeFields
-    //   };
-    // } else {
-    //   baseBlock = {
-    //     type: 'section',
-    //     fields: slackBlockUI.baseFields
-    //   };
-    // }
 
-    if (commitFlag && token) {
-      const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(
-        token
+    let baseBlock;
+
+    if (isCompactMode) {
+      const compactModeFields: MrkdwnElement = await slackBlockUI.getCompactModeFields(
+        result
       );
-      Array.prototype.push.apply(baseBlock['fields'], commitFields);
+      baseBlock = {
+        type: 'section',
+        text: compactModeFields
+      };
+    } else {
+      baseBlock = {
+        type: 'section',
+        fields: slackBlockUI.baseFields
+      };
+
+      if (commitFlag && token) {
+        const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(
+          token
+        );
+        Array.prototype.push.apply(baseBlock['fields'], commitFields);
+      }
     }
 
     const attachments: MessageAttachment = {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -122,7 +122,7 @@ class Block {
    * @returns {Promise<MrkdwnElement[]>}
    */
   public async getCompactModeFields(status: string): Promise<MrkdwnElement[]> {
-    const {sha, eventName, workflow, ref,actor} = this.context;
+    const {workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
     let actionUrl: string = repoUrl;
@@ -130,7 +130,7 @@ class Block {
     const fields: MrkdwnElement[] = [
       {
         type: 'mrkdwn',
-        text: `It was ${status} on ${ref} by, check <${actionUrl}|${workflow}> ${actor} `
+        text: `It was ${status} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
       }
     ];
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -121,13 +121,13 @@ class Block {
    * Get MrkdwnElement for compact mode
    * @returns {Promise<MrkdwnElement[]>}
    */
-  public async getCompactModeFields(): Promise<MrkdwnElement[]> {
+  public async getCompactModeFields(status: string): Promise<MrkdwnElement[]> {
     const {sha, eventName, workflow, ref} = this.context;
 
     const fields: MrkdwnElement[] = [
       {
         type: 'mrkdwn',
-        text: `on ${ref}`
+        text: `It has ${status} on ${ref}`
       }
     ];
 
@@ -176,7 +176,7 @@ export class Slack {
     };
 
     if (isCompactMode) {
-      const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields();
+      const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(status);
       baseBlock.fields = compactModeFields;
     }
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -123,11 +123,14 @@ class Block {
    */
   public async getCompactModeFields(status: string): Promise<MrkdwnElement[]> {
     const {sha, eventName, workflow, ref} = this.context;
-
+    const {owner, repo} = this.context.repo;
+    const repoUrl: string = `https://github.com/${owner}/${repo}`;
+    let actionUrl: string = repoUrl;
+    
     const fields: MrkdwnElement[] = [
       {
         type: 'mrkdwn',
-        text: `It has ${status} on ${ref}`
+        text: `It has ${status} on ${ref}, check <${actionUrl}|${workflow}>`
       }
     ];
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -121,18 +121,17 @@ class Block {
    * Get MrkdwnElement for compact mode
    * @returns {Promise<MrkdwnElement[]>}
    */
-  public async getCompactModeFields(result: String): Promise<MrkdwnElement[]> {
+  public async getCompactModeFields(result: String): Promise<MrkdwnElement> {
     const {workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
     let actionUrl: string = repoUrl;
 
-    const fields: MrkdwnElement[] = [
-      {
-        type: 'mrkdwn',
-        text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
-      }
-    ];
+    const fields: MrkdwnElement = 
+    {
+      type: 'mrkdwn',
+      text: `It has ${result} by <@${actor}> on ${ref}, check <${actionUrl}|${workflow}>`
+    };
 
     return fields;
   }
@@ -174,7 +173,7 @@ export class Slack {
       mention && this.isMention(mentionCondition, status)
         ? `<!${mention}> ${tmpText}`
         : tmpText;
-    const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
+    const compactModeFields: MrkdwnElement = await slackBlockUI.getCompactModeFields(
       result
     );
     let baseBlock = {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -176,21 +176,21 @@ export class Slack {
         : tmpText;
     let baseBlock = {
       type: 'section',
-      text: slackBlockUI.baseFields
+      fields: slackBlockUI.baseFields
     };
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
         result
       );
-      baseBlock.text = compactModeFields;
+      baseBlock.fields = compactModeFields;
     }
 
     if (commitFlag && token) {
       const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(
         token
       );
-      Array.prototype.push.apply(baseBlock.text, commitFields);
+      Array.prototype.push.apply(baseBlock.fields, commitFields);
     }
 
     const attachments: MessageAttachment = {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -173,21 +173,17 @@ export class Slack {
         ? `<!${mention}> ${tmpText}`
         : tmpText;
 
-    let baseBlock;
+    let baseBlock = {
+      type: 'section'
+    };
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement = await slackBlockUI.getCompactModeFields(
         result
       );
-      baseBlock = {
-        type: 'section',
-        text: compactModeFields
-      };
+      baseBlock['text'] = compactModeFields;
     } else {
-      baseBlock = {
-        type: 'section',
-        fields: slackBlockUI.baseFields
-      };
+      baseBlock['fields'] = slackBlockUI.baseFields;
 
       if (commitFlag && token) {
         const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -174,7 +174,7 @@ export class Slack {
       mention && this.isMention(mentionCondition, status)
         ? `<!${mention}> ${tmpText}`
         : tmpText;
-    let baseBlock
+    let baseBlock;
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
@@ -182,13 +182,13 @@ export class Slack {
       );
       baseBlock = {
         type: 'section',
-        text: compactModeFields,
-      }
-    }else{
+        text: compactModeFields
+      };
+    } else {
       baseBlock = {
         type: 'section',
-        fields : slackBlockUI.baseFields
-      };  
+        fields: slackBlockUI.baseFields
+      };
     }
 
     if (commitFlag && token) {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -121,7 +121,7 @@ class Block {
    * Get MrkdwnElement for compact mode
    * @returns {Promise<MrkdwnElement[]>}
    */
-  public async getCompactModeFields(result: String  ): Promise<MrkdwnElement[]> {
+  public async getCompactModeFields(result: String): Promise<MrkdwnElement[]> {
     const {workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
@@ -168,7 +168,7 @@ export class Slack {
   ): Promise<IncomingWebhookSendArguments> {
     const slackBlockUI = new Block();
     const notificationType: Accessory = slackBlockUI[status];
-    const {result} = notificationType
+    const {result} = notificationType;
     const tmpText: string = `${jobName} ${result}`;
     const text =
       mention && this.isMention(mentionCondition, status)

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -121,9 +121,7 @@ class Block {
    * Get MrkdwnElement for compact mode
    * @returns {Promise<MrkdwnElement[]>}
    */
-  public async getCompactModeFields(
-    notificationType: Accessory
-  ): Promise<MrkdwnElement[]> {
+  public async getCompactModeFields(result: String  ): Promise<MrkdwnElement[]> {
     const {workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
@@ -132,7 +130,7 @@ class Block {
     const fields: MrkdwnElement[] = [
       {
         type: 'mrkdwn',
-        text: `It has ${notificationType.result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
+        text: `It has ${result} by ${actor} on ${ref}, check <${actionUrl}|${workflow}>`
       }
     ];
 
@@ -170,7 +168,8 @@ export class Slack {
   ): Promise<IncomingWebhookSendArguments> {
     const slackBlockUI = new Block();
     const notificationType: Accessory = slackBlockUI[status];
-    const tmpText: string = `${jobName} ${notificationType.result}`;
+    const {result} = notificationType
+    const tmpText: string = `${jobName} ${result}`;
     const text =
       mention && this.isMention(mentionCondition, status)
         ? `<!${mention}> ${tmpText}`
@@ -182,7 +181,7 @@ export class Slack {
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
-        notificationType
+        result
       );
       baseBlock.fields = compactModeFields;
     }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -175,24 +175,23 @@ export class Slack {
         ? `<!${mention}> ${tmpText}`
         : tmpText;
     let baseBlock = {
-      type: 'section',
+      type: 'section'
     };
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
         result
       );
-      baseBlock["text"] = compactModeFields;
-    } 
-    else {
-      baseBlock["fields"] = slackBlockUI.baseFields
+      baseBlock['text'] = compactModeFields;
+    } else {
+      baseBlock['fields'] = slackBlockUI.baseFields;
     }
 
     if (commitFlag && token) {
       const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(
         token
       );
-      Array.prototype.push.apply(baseBlock["fields"], commitFields);
+      Array.prototype.push.apply(baseBlock['fields'], commitFields);
     }
 
     const attachments: MessageAttachment = {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -121,7 +121,9 @@ class Block {
    * Get MrkdwnElement for compact mode
    * @returns {Promise<MrkdwnElement[]>}
    */
-  public async getCompactModeFields(notificationType:Accessory): Promise<MrkdwnElement[]> {
+  public async getCompactModeFields(
+    notificationType: Accessory
+  ): Promise<MrkdwnElement[]> {
     const {workflow, ref, actor} = this.context;
     const {owner, repo} = this.context.repo;
     const repoUrl: string = `https://github.com/${owner}/${repo}`;
@@ -180,7 +182,7 @@ export class Slack {
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
-        notificationType,
+        notificationType
       );
       baseBlock.fields = compactModeFields;
     }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -174,17 +174,21 @@ export class Slack {
       mention && this.isMention(mentionCondition, status)
         ? `<!${mention}> ${tmpText}`
         : tmpText;
-    let baseBlock = {
-      type: 'section'
-    };
+    let baseBlock
 
     if (isCompactMode) {
       const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
         result
       );
-      baseBlock['text'] = compactModeFields;
-    } else {
-      baseBlock['fields'] = slackBlockUI.baseFields;
+      baseBlock = {
+        type: 'section',
+        text: compactModeFields,
+      }
+    }else{
+      baseBlock = {
+        type: 'section',
+        fields : slackBlockUI.baseFields
+      };  
     }
 
     if (commitFlag && token) {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -174,22 +174,27 @@ export class Slack {
       mention && this.isMention(mentionCondition, status)
         ? `<!${mention}> ${tmpText}`
         : tmpText;
-    let baseBlock;
-
-    if (isCompactMode) {
-      const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
-        result
-      );
-      baseBlock = {
-        type: 'section',
-        text: compactModeFields
-      };
-    } else {
-      baseBlock = {
-        type: 'section',
-        fields: slackBlockUI.baseFields
-      };
-    }
+    const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
+      result
+    );
+    let baseBlock = {
+      type: 'section',
+      text: compactModeFields
+    };
+    // if (isCompactMode) {
+    //   const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
+    //     result
+    //   );
+    //   baseBlock = {
+    //     type: 'section',
+    //     text: compactModeFields
+    //   };
+    // } else {
+    //   baseBlock = {
+    //     type: 'section',
+    //     fields: slackBlockUI.baseFields
+    //   };
+    // }
 
     if (commitFlag && token) {
       const commitFields: MrkdwnElement[] = await slackBlockUI.getCommitFields(

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -176,7 +176,9 @@ export class Slack {
     };
 
     if (isCompactMode) {
-      const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(status);
+      const compactModeFields: MrkdwnElement[] = await slackBlockUI.getCompactModeFields(
+        status
+      );
       baseBlock.fields = compactModeFields;
     }
 


### PR DESCRIPTION

<img width="717" alt="スクリーンショット 2020-04-21 11 23 13" src="https://user-images.githubusercontent.com/48426654/79818365-97afdb00-83c2-11ea-9486-7c141f096096.png">


ここまででキリが良いので、一旦 master もコンパクトモードが飛ぶよう変更したいです。
yml を書き換えるタスクを作りました https://youtrack.weseek.co.jp/issue/GW-1921
